### PR TITLE
Fix compatibility with asdf v0.16.0

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -67,7 +67,8 @@ install_version() {
     mkdir -p "$install_path/bin"
     download_release "$version" "$release_file"
     # command line parameters are copied from openapi-generator-cli.sh (https://github.com/OpenAPITools/openapi-generator/blob/master/bin/utils/openapi-generator-cli.sh)
-    echo 'java -ea ${JAVA_OPTS} -Xms512M -Xmx1024M -server -jar '"$release_file"' "$@"' >"$script_file"
+    echo '#!/bin/sh' >"$script_file"
+    echo 'java -ea ${JAVA_OPTS} -Xms512M -Xmx1024M -server -jar '"$release_file"' "$@"' >>"$script_file"
     chmod +x "$script_file"
 
     local tool_cmd


### PR DESCRIPTION
https://asdf-vm.com/guide/upgrading-to-v0-16.html#executables-shims-resolve-to-must-runnable-by-syscall-exec